### PR TITLE
Update easy-wi_install.sh

### DIFF
--- a/server/easy-wi_install.sh
+++ b/server/easy-wi_install.sh
@@ -683,7 +683,6 @@ if [ "$INSTALL" != 'VS' -a "$INSTALL" != 'EW' ]; then
 			/etc/init.d/proftpd restart
 		fi
 	fi
-fi
 
 if [ "$INSTALL" == 'GS' -o "$INSTALL" == 'WR' ]; then
 


### PR DESCRIPTION
./easy-wi_install.sh: line 686: syntax error near unexpected token `fi'
./easy-wi_install.sh: line 686:`fi'
