### PR TITLE
Added force to all rm commands

### DIFF
--- a/server/control.sh
+++ b/server/control.sh
@@ -80,7 +80,7 @@ function wget_remove {
 			RETRY=$[RETRY+1]
 		done
 		if [ "$RETRY" -lt 10 ]; then
-			rm wget-log > /dev/null 2>&1
+			rm -f wget-log > /dev/null 2>&1
 			find $HOMEFOLDER -maxdepth 1 -name "control_new.*" -delete
 			find $HOMEFOLDER \( -iname "wget-*" \) -delete
 			find $HOMEFOLDER/conf/ -maxdepth 1 -name "wget-*" -delete
@@ -101,11 +101,11 @@ function updatecheck {
 		CURRENTFDLVERSION=`wget -q --timeout=10 -O - http://update.easy-wi.com/if_version.php | sed 's/^\xef\xbb\xbf//g'`
 		if [ -z $CURRENTFDLVERSION ]; then
 			cd $HOMEFOLDER
-			if [ -f $HOMEFOLDER/control_new.tar ]; then rm $HOMEFOLDER/control_new.tar; fi
+			if [ -f $HOMEFOLDER/control_new.tar ]; then rm -f $HOMEFOLDER/control_new.tar; fi
 		elif [ "$CVERSION" != "$CURRENTFDLVERSION" ]; then
 			if [ "$ISROOT" == "1" ]; then echo "control.sh is outdated fetching update"; fi
 			cd $HOMEFOLDER
-			if [ -f $HOMEFOLDER/control_new.tar ]; then rm $HOMEFOLDER/control_new.tar; fi
+			if [ -f $HOMEFOLDER/control_new.tar ]; then rm -f $HOMEFOLDER/control_new.tar; fi
 			wget -q --timeout=10 http://update.easy-wi.com/programs/bash/control_new.tar
 			if [ -f $HOMEFOLDER/control_new.tar ]; then
 				tar xfp control_new.tar
@@ -123,11 +123,11 @@ function updatecheck {
 					OLDVERSION=`ls $HOMEFOLDER/control.old.*.sh | sort -f -r | head -n1`
 					if [ "$OLDVERSION" != "" ]; then mv $OLDVERSION $HOMEFOLDER/control.sh; fi
 				fi
-				rm control_new.tar control_new.tar.* control_new.sh control.tar.* control.old.2.3.* 2> /dev/null
+				rm -f control_new.tar control_new.tar.* control_new.sh control.tar.* control.old.2.3.* 2> /dev/null
 			fi
 			if [ "$ISROOT" == "1" ]; then echo "control.sh has been updated to version $CURRENTFDLVERSION."; fi
 		fi
-		rm $HOMEFOLDER/.updateLock
+		rm -f $HOMEFOLDER/.updateLock
 	fi
 }
 if [ "$NOUPDATES" != "1" -a "$SCRIPTNAME" != "control_new.sh" -a "$VARIABLE1" != "fixpermissions" ]; then
@@ -138,7 +138,7 @@ if [ "$NOUPDATES" != "1" -a "$SCRIPTNAME" != "control_new.sh" -a "$VARIABLE1" !=
 		ISROOT=1
 		updatecheck
 		if [ "`find -maxdepth 1 -name \"control.old.*\"`" != "" ]; then
-			rm control.old.*
+			rm -f control.old.*
 		fi
 	fi
 fi
@@ -488,7 +488,7 @@ cd /home/$INSTALLMASTER/masterserver/steamCMD/
 wget -q --timeout=10 http://media.steampowered.com/client/steamcmd_linux.tar.gz
 if [ -f steamcmd_linux.tar.gz ]; then
 	tar xfvz steamcmd_linux.tar.gz
-	rm steamcmd_linux.tar.gz
+	rm -f steamcmd_linux.tar.gz
 	chown -R $INSTALLMASTER:$INSTALLMASTER /home/$INSTALLMASTER/
 	su -c "./steamcmd.sh +login anonymous +quit" $INSTALLMASTER
 fi
@@ -573,7 +573,7 @@ function publicKeyGenerate {
 		INSTALLMASTER=`whoami`
 	fi
 	if [ "$INSTALLMASTER" != "" ]; then
-		if [ -d /home/$INSTALLMASTER/.ssh ]; then rm -r /home/$INSTALLMASTER/.ssh; fi
+		if [ -d /home/$INSTALLMASTER/.ssh ]; then rm -rf /home/$INSTALLMASTER/.ssh; fi
 		if [ "`id -u`" == "0" ]; then
 			su -c 'ssh-keygen -t rsa' $INSTALLMASTER
 		else
@@ -598,7 +598,7 @@ function fdlList {
 	echo "PATTERN=$PATTERN" >> $1
 	echo "SED=\"sed \"'s/\.\///g'\"\"" >> $1
 	echo "if [ -f $HOMEFOLDER/conf/fdl-$UPDATE.list ]; then" >> $1
-	echo "	rm $HOMEFOLDER/conf/fdl-$UPDATE.list" >> $1
+	echo "	rm -f $HOMEFOLDER/conf/fdl-$UPDATE.list" >> $1
 	echo 'fi' >> $1
 	echo "touch $HOMEFOLDER/conf/fdl-$UPDATE.list" >> $1
 	echo "cd $MASTERSERVERDIR/$UPDATE" >> $1
@@ -634,7 +634,7 @@ ps x | grep 'SteamCmdUpdate-Screen'  | grep -v 'grep' | awk '{print $1}' | while
 done
 cat > $TEMPFOLDER/updateSteamCmd.sh << EOF
 #!/bin/bash
-rm $TEMPFOLDER/updateSteamCmd.sh
+rm -f $TEMPFOLDER/updateSteamCmd.sh
 VARIABLE3="$VARIABLE3"
 VARIABLE4="$VARIABLE4"
 VARIABLE5="$VARIABLE5"
@@ -653,7 +653,7 @@ if [ ! -d "$MASTERSERVERDIR/steamCMD/" ]; then
 		wget -q --timeout=10 http://media.steampowered.com/client/steamcmd_linux.tar.gz
 		if [ -f steamcmd_linux.tar.gz ]; then
 			tar xfz steamcmd_linux.tar.gz
-			rm steamcmd_linux.tar.gz
+			rm -f steamcmd_linux.tar.gz
 			chmod +x steamcmd.sh
 			./steamcmd.sh +login anonymous +quit
 		fi
@@ -781,7 +781,7 @@ for UPDATE in $VARIABLE3; do
 	if [[ ! `screen -ls | grep $UPDATE.update` ]]; then
 cat > $TEMPFOLDER/update_$UPDATE.sh << EOF
 #!/bin/bash
-rm $TEMPFOLDER/update_$UPDATE.sh
+rm -f $TEMPFOLDER/update_$UPDATE.sh
 VARIABLE4="$VARIABLE4"
 VARIABLE5="$VARIABLE5"
 LOGDIR="$LOGDIR"
@@ -950,7 +950,7 @@ echo "`date`: User $VARIABLE2 created" >> $LOGDIR/update.log
 
 function customerDelete {
 echo "#!/bin/bash
-rm $HOMEFOLDER/temp/del-user-${VARIABLE2}.sh
+rm -f $HOMEFOLDER/temp/del-user-${VARIABLE2}.sh
 #${IONICE}nice -n +19 sudo /usr/sbin/deluser --remove-all-files ${VARIABLE2}-p
 #${IONICE}nice -n +19 sudo /usr/sbin/deluser --remove-all-files ${VARIABLE2}
 ${IONICE}nice -n +19 sudo /usr/sbin/userdel -fr ${VARIABLE2}-p
@@ -963,7 +963,7 @@ echo "`date`: User $VARIABLE2 deleted" >> $LOGDIR/update.log
 function user_single_delete {
 if [ "`id ${VARIABLE2} 2>/dev/null`" != "" ]; then
 echo "#!/bin/bash
-rm $HOMEFOLDER/temp/del-user-${VARIABLE2}.sh
+rm -f $HOMEFOLDER/temp/del-user-${VARIABLE2}.sh
 ${IONICE}nice -n +19 sudo /usr/sbin/userdel -fr ${VARIABLE2}" > $HOMEFOLDER/temp/del-user-${VARIABLE2}.sh
 chmod +x $HOMEFOLDER/temp/del-user-${VARIABLE2}.sh
 screen -d -m -S del-user-${VARIABLE2} $HOMEFOLDER/temp/del-user-${VARIABLE2}.sh
@@ -1060,7 +1060,7 @@ SERVERDIR=`echo $SERVERDIR | sed 's/\/\//\//g'`
 echo "#!/bin/bash
 
 HOMEFOLDER=$HOMEFOLDER
-rm $HOMEFOLDER/temp/del-$VARIABLE2-$VARIABLE4.sh
+rm -f $HOMEFOLDER/temp/del-$VARIABLE2-$VARIABLE4.sh
 VARIABLE2=$VARIABLE2
 VARIABLE4=$VARIABLE4
 SERVERDIR=$SERVERDIR" > $HOMEFOLDER/temp/del-$VARIABLE2-$VARIABLE4.sh
@@ -1122,7 +1122,7 @@ if [ "$VARIABLE1" != "migrateserver" ]; then
 echo "#!/bin/bash
 
 HOMEFOLDER=$HOMEFOLDER
-rm $HOMEFOLDER/temp/add-$VARIABLE2-$VARIABLE4.sh
+rm -f $HOMEFOLDER/temp/add-$VARIABLE2-$VARIABLE4.sh
 VARIABLE2=$VARIABLE2
 VARIABLE4=$VARIABLE4
 SERVERDIR=$SERVERDIR
@@ -1211,7 +1211,7 @@ function migration {
 echo "#!/bin/bash
 
 HOMEFOLDER=$HOMEFOLDER
-rm $HOMEFOLDER/temp/add-$VARIABLE2-$VARIABLE4.sh
+rm -f $HOMEFOLDER/temp/add-$VARIABLE2-$VARIABLE4.sh
 VARIABLE2=$VARIABLE2
 VARIABLE4=$VARIABLE4
 VARIABLE9=$VARIABLE9
@@ -1250,7 +1250,7 @@ VARIABLE2=$VARIABLE2
 VARIABLE3=$VARIABLE3
 VARIABLE4=$VARIABLE4
 VARIABLE5=$VARIABLE5
-rm $HOMEFOLDER/temp/move-$VARIABLE2-$VARIABLE4.sh" > $HOMEFOLDER/temp/move-$VARIABLE2-$VARIABLE4.sh
+rm -f $HOMEFOLDER/temp/move-$VARIABLE2-$VARIABLE4.sh" > $HOMEFOLDER/temp/move-$VARIABLE2-$VARIABLE4.sh
 echo 'while [[ `screen -ls | grep "del-$VARIABLE2-$VARIABLE3"` ]]; do
 	sleep 1
 done' >> $HOMEFOLDER/temp/move-$VARIABLE2-$VARIABLE4.sh
@@ -1302,7 +1302,7 @@ function map_list {
 			elif [[ `find -name da2` ]]; then
 				cd `find -name da2`
 			fi
-			if [ -f maplist.txt ]; then rm maplist.txt; fi
+			if [ -f maplist.txt ]; then rm -f maplist.txt; fi
 			if [ "$MAPTYPE" == "bsp" ]; then
 				cd `find -maxdepth 3 -type d -name "maps" | head -n 1`
 			elif [ "$MAPTYPE" == "rom" ]; then
@@ -1347,7 +1347,7 @@ function backup_servers {
 	BACKUPDIR="$USERHOME/$USERNAME/backup"
 	echo "#!/bin/bash
 
-rm $HOMEFOLDER/temp/backup-$VARIABLE2-$USERNAME.sh
+rm -f $HOMEFOLDER/temp/backup-$VARIABLE2-$USERNAME.sh
 BACKUPDIR=$BACKUPDIR
 USERNAME=$USERNAME
 USERHOME=$USERHOME" > $HOMEFOLDER/temp/backup-$VARIABLE2-$USERNAME.sh
@@ -1388,7 +1388,7 @@ function restore_backup {
 	SCREENNAME=restorerestore-$VARIABLE2-$VARIABLE3
 	if ([[ ! `screen -ls | grep "$SCREENNAME"` ]] && [[ ! `screen -ls | grep "backup-$VARIABLE2-$SHORTEN"` ]]); then
 		echo "#!/bin/bash" > $HOMEFOLDER/temp/restore-$VARIABLE2-$VARIABLE3-$USERNAME.sh
-		echo "rm $HOMEFOLDER/temp/restore-$VARIABLE2-$VARIABLE3-$USERNAME.sh" >> $HOMEFOLDER/temp/restore-$VARIABLE2-$VARIABLE3-$USERNAME.sh
+		echo "rm -f $HOMEFOLDER/temp/restore-$VARIABLE2-$VARIABLE3-$USERNAME.sh" >> $HOMEFOLDER/temp/restore-$VARIABLE2-$VARIABLE3-$USERNAME.sh
 		echo "USERHOME=$USERHOME" >> $HOMEFOLDER/temp/restore-$VARIABLE2-$VARIABLE3-$USERNAME.sh
 		if [ "$VARIABLE5" != "" -a "$VARIABLE5" != "none" ]; then
 			echo "if [ ! -f $USERHOME/$USERNAME/backup/ ]; then mkdir -p $USERHOME/$USERNAME/backup/; fi" >> $HOMEFOLDER/temp/restore-$VARIABLE2-$VARIABLE3-$USERNAME.sh
@@ -1396,7 +1396,7 @@ function restore_backup {
 			echo "mv $USERHOME/$USERNAME/backup/$VARIABLE2-$VARIABLE3.tar.bz2 $USERHOME/$USERNAME/backup/$VARIABLE2-${VARIABLE3}_old.tar.bz2" >> $HOMEFOLDER/temp/restore-$VARIABLE2-$VARIABLE3-$USERNAME.sh
 			echo "wget -q --timeout=10 --no-check-certificate $VARIABLE5/$VARIABLE2-$VARIABLE3.tar.bz2" >> $HOMEFOLDER/temp/restore-$VARIABLE2-$VARIABLE3-$USERNAME.sh
 			echo "if [ -f $USERHOME/$USERNAME/backup/$VARIABLE2-$VARIABLE3.tar.bz2 ]; then" >> $HOMEFOLDER/temp/restore-$VARIABLE2-$VARIABLE3-$USERNAME.sh
-			echo "	rm $USERHOME/$USERNAME/backup/$VARIABLE2-${VARIABLE3}_old.tar.bz2" >> $HOMEFOLDER/temp/restore-$VARIABLE2-$VARIABLE3-$USERNAME.sh
+			echo "	rm -f $USERHOME/$USERNAME/backup/$VARIABLE2-${VARIABLE3}_old.tar.bz2" >> $HOMEFOLDER/temp/restore-$VARIABLE2-$VARIABLE3-$USERNAME.sh
 			echo "else" >> $HOMEFOLDER/temp/restore-$VARIABLE2-$VARIABLE3-$USERNAME.sh
 			echo "	mv $USERHOME/$USERNAME/backup/$VARIABLE2-${VARIABLE3}_old.tar.bz2 $USERHOME/$USERNAME/backup/$VARIABLE2-$VARIABLE3.tar.bz2" >> $HOMEFOLDER/temp/restore-$VARIABLE2-$VARIABLE3-$USERNAME.sh
 			echo "fi" >> $HOMEFOLDER/temp/restore-$VARIABLE2-$VARIABLE3-$USERNAME.sh
@@ -1530,7 +1530,7 @@ for ISFILE in $DONOTTOUCH; do
 		MASTERPATH=`echo "$HOMEFOLDER/masterserver/$MASTERGAME/$MASTERGAMEFOLDER/$BADFILE" | sed 's/\/\//\//g'`
 		BADFILEPATH=`echo "$SERVERDIR/$BADFILE" | sed 's/\/\//\//g'`
 		chmod 666 $BADFILE
-		rm $BADFILE
+		rm -f $BADFILE
 		if [ -f $BADFILE ]; then
 			exit 0
 		fi
@@ -1542,7 +1542,7 @@ for ISFILE in $DONOTTOUCH; do
 		MASTERPATH=`echo "$HOMEFOLDER/masterserver/$MASTERGAME/$MASTERGAMEFOLDER/$BADFILE" | sed 's/\/\//\//g'`
 		BADFILEPATH=`echo "$SERVERDIR/$BADFILE" | sed 's/\/\//\//g'`
 		if [ "`ls -la $BADFILE | awk '{print $11}'`" != "$MASTERPATH" ]; then
-			rm $BADFILE
+			rm -f $BADFILE
 			if [ -f $BADFILE ]; then
 				exit 0
 			fi
@@ -1604,7 +1604,7 @@ else
 		fi
 		if [ ! -f $STARTFILE ]; then
 		echo '#!/bin/bash' > $STARTFILE
-		echo "rm $STARTFILE" >> $STARTFILE
+		echo "rm -f $STARTFILE" >> $STARTFILE
 		echo 'while [ "`ps x | grep '"'add-${VARIABLE2}'"' | grep -v grep`" != "" ]; do' >> $STARTFILE
 		echo 'sleep 0.5' >> $STARTFILE
 		echo 'done' >> $STARTFILE
@@ -1637,7 +1637,7 @@ else
 		echo 'if [ "`find orangebox/ css/ -type f 2> /dev/null | wc -l`" == "0" ]; then rm -rf orangebox/ css/ 2> /dev/null; fi' >> $STARTFILE
 		echo 'fi' >> $STARTFILE
 		# Steampipe Fix Ende
-		echo "if [ -f screenlog.0 ]; then rm screenlog.0; fi" >> $STARTFILE
+		echo "if [ -f screenlog.0 ]; then rm -f screenlog.0; fi" >> $STARTFILE
 		echo "${TASKSET} screen -A -m -d -L -S $SCREENNAME $VARIABLE4" >> $STARTFILE
 		chmod +x $STARTFILE
 		$STARTFILE > /dev/null 2>&1 &
@@ -1684,7 +1684,7 @@ else
 fi
 if [ "$VARIABLE1" == "grestart" ]; then
 	echo '#!/bin/bash' > $STARTFILE
-	echo "rm $STARTFILE" >> $STARTFILE
+	echo "rm -f $STARTFILE" >> $STARTFILE
 	echo "SCREENNAME=$SCREENNAME" >> $STARTFILE
 	echo 'while [ "`ps x | egrep '"'add-${VARIABLE2}|del-${VARIABLE2}|move-${VARIABLE2}'"' | grep -v grep`" != "" ]; do' >> $STARTFILE
 	echo 'sleep 0.5' >> $STARTFILE
@@ -1692,7 +1692,7 @@ if [ "$VARIABLE1" == "grestart" ]; then
 	addStop $STARTFILE temp/start-${VARIABLE2}-p-${SCREENNAME}.sh
 else
 	echo "#!/bin/bash" > $HOMEFOLDER/temp/fullstop-${VARIABLE2}-${SCREENNAME}.sh
-	echo "rm $HOMEFOLDER/temp/fullstop-${VARIABLE2}-${SCREENNAME}.sh" >> $HOMEFOLDER/temp/fullstop-${VARIABLE2}-${SCREENNAME}.sh
+	echo "rm -f $HOMEFOLDER/temp/fullstop-${VARIABLE2}-${SCREENNAME}.sh" >> $HOMEFOLDER/temp/fullstop-${VARIABLE2}-${SCREENNAME}.sh
 	echo "SCREENNAME=$SCREENNAME" >> $HOMEFOLDER/temp/fullstop-${VARIABLE2}-${SCREENNAME}.sh
 	addStop $HOMEFOLDER/temp/fullstop-${VARIABLE2}-${SCREENNAME}.sh temp/fullstop-${VARIABLE2}-${SCREENNAME}.sh
 	echo "${IONICE}nice -n +19 find $HOMEFOLDER/temp/ -type f -user `whoami` -delete" >> $HOMEFOLDER/temp/fullstop-${VARIABLE2}-${SCREENNAME}.sh
@@ -1796,7 +1796,7 @@ function demo_upload {
 		cat > $TEMPFOLDER/$USERNAME-$SCREENNAME-upload.sh <<EOF
 #!/bin/bash
 
-rm $TEMPFOLDER/$USERNAME-$SCREENNAME-upload.sh
+rm -f $TEMPFOLDER/$USERNAME-$SCREENNAME-upload.sh
 VARIABLE3="$VARIABLE3/"
 VARIABLE4="$VARIABLE4"
 KEEP="$KEEP"
@@ -1883,7 +1883,7 @@ function copy_addon_files {
 
 function sync_addons {
 	echo "#!/bin/bash" > $HOMEFOLDER/temp/sync-addons.sh
-	echo "rm $HOMEFOLDER/temp/sync-addons.sh" >> $HOMEFOLDER/temp/sync-addons.sh
+	echo "rm -f $HOMEFOLDER/temp/sync-addons.sh" >> $HOMEFOLDER/temp/sync-addons.sh
 	if [ "$VARIABLE3" != "maps" ]; then
 		echo "cd $MAPDIR/" >> $HOMEFOLDER/temp/sync-addons.sh
 		for MAPPACKAGE in $VARIABLE3; do
@@ -1920,7 +1920,7 @@ function sync_addons {
 
 function sync_server {
 	echo "#!/bin/bash" > $TEMPFOLDER/sync-server.sh
-	echo "rm $TEMPFOLDER/sync-server.sh" >> $TEMPFOLDER/sync-server.sh
+	echo "rm -f $TEMPFOLDER/sync-server.sh" >> $TEMPFOLDER/sync-server.sh
 	echo "cd $MASTERSERVERDIR/" >> $TEMPFOLDER/sync-server.sh
 	echo "BOMRM=\"sed \"'s/^\xef\xbb\xbf//g'\"\"" >> $TEMPFOLDER/sync-server.sh
 	for SERVER in $VARIABLE3; do
@@ -2006,12 +2006,12 @@ function del_addon_files {
 		if [ "`basename $FILES`" == "liblist.gam" ]; then
 			mv $GAMEDIR/$FILES.old $GAMEDIR/$FILES
 		elif [ "`basename $FILES`" == "plugins.ini" ]; then
-			if [ -f $HOMEFOLDER/temp/$USER.pluginlist.temp ]; then rm $HOMEFOLDER/temp/$USER.pluginlist.temp; fi
+			if [ -f $HOMEFOLDER/temp/$USER.pluginlist.temp ]; then rm -f $HOMEFOLDER/temp/$USER.pluginlist.temp; fi
 			cat $GAMEDIR/$FILES | while read LINE; do
 				if [[ `grep "$LINE" $FILES` == "" ]]; then  echo "$LINE" >> $HOMEFOLDER/temp/$USER.pluginlist.temp; fi
 			done
 			cp $HOMEFOLDER/temp/$USER.pluginlist.temp $GAMEDIR/$FILES
-			rm $HOMEFOLDER/temp/$USER.pluginlist.temp
+			rm -f $HOMEFOLDER/temp/$USER.pluginlist.temp
 		else
 			rm -rf "$GAMEDIR/$FILES" > /dev/null 2>&1
 			if [ "$FILES" == "liblist.gam" ]; then mv $GAMEDIR/$FILES.old $GAMEDIR/$FILES > /dev/null 2>&1; fi
@@ -2098,11 +2098,11 @@ function fdl_update {
 			SERVERDIR=`readlink -f $GSMODFOLDER`
 		fi
 		if [ -f $HOMEFOLDER/temp/$VARIABLE2-$SPORT-$SHORTEN.sh ]; then
-			rm $HOMEFOLDER/temp/$VARIABLE2-$SPORT-$SHORTEN.sh
+			rm -f $HOMEFOLDER/temp/$VARIABLE2-$SPORT-$SHORTEN.sh
 		fi
 		PATTERN="\.log\|\.txt\|\.cfg\|\.vdf\|\.db\|\.dat\|\.ztmp\|\.blib\|log\/\|logs\/\|downloads\/\|DownloadLists\/\|metamod\/\|amxmodx\/\|hl\/\|hl2\/\|cfg\/\|addons\/\|bin\/\|classes/"
 		echo "#!/bin/bash" > $HOMEFOLDER/temp/$VARIABLE2-$SPORT-$SHORTEN.sh
-		echo "rm $HOMEFOLDER/temp/$VARIABLE2-$SPORT-$SHORTEN.sh" >> $HOMEFOLDER/temp/$VARIABLE2-$SPORT-$SHORTEN.sh
+		echo "rm -f $HOMEFOLDER/temp/$VARIABLE2-$SPORT-$SHORTEN.sh" >> $HOMEFOLDER/temp/$VARIABLE2-$SPORT-$SHORTEN.sh
 		echo "GAMETYPE=$GAMETYPE" >> $HOMEFOLDER/temp/$VARIABLE2-$SPORT-$SHORTEN.sh
 		echo "HOMEFOLDER=$HOMEFOLDER" >> $HOMEFOLDER/temp/$VARIABLE2-$SPORT-$SHORTEN.sh
 		echo "VARIABLE2=$VARIABLE2" >> $HOMEFOLDER/temp/$VARIABLE2-$SPORT-$SHORTEN.sh
@@ -2142,7 +2142,7 @@ function fdl_update {
 			echo '			if [ "`head -n 1 \"$DATADIR/$GAMETYPE/$SHORTEN/$FILTEREDFILES.stat\"`" != "`'"${IONICE}"'nice -n +19 md5sum \"$FILTEREDFILES\" | awk '"'"'{print $1}'"'"'`" ]; then' >> $HOMEFOLDER/temp/$VARIABLE2-$SPORT-$SHORTEN.sh
 			echo '				'"${IONICE}"'nice -n +19 md5sum "$FILTEREDFILES" | awk '"'"'{print $1}'"'"' > "$DATADIR/$GAMETYPE/$SHORTEN/$FILTEREDFILES.stat"' >> $HOMEFOLDER/temp/$VARIABLE2-$SPORT-$SHORTEN.sh
 			echo '				if [ -f "$DATADIR/$GAMETYPE/$SHORTEN/$FILTEREDFILES.bz2" ]; then' >> $HOMEFOLDER/temp/$VARIABLE2-$SPORT-$SHORTEN.sh
-			echo '					'"${IONICE}"'nice -n +19 rm "$DATADIR/$GAMETYPE/$SHORTEN/$FILTEREDFILES.bz2"' >> $HOMEFOLDER/temp/$VARIABLE2-$SPORT-$SHORTEN.sh
+			echo '					'"${IONICE}"'nice -n +19 rm -f "$DATADIR/$GAMETYPE/$SHORTEN/$FILTEREDFILES.bz2"' >> $HOMEFOLDER/temp/$VARIABLE2-$SPORT-$SHORTEN.sh
 			echo '				fi' >> $HOMEFOLDER/temp/$VARIABLE2-$SPORT-$SHORTEN.sh
 			echo '				'"${IONICE}"'nice -n +19 bzip2 -k -s -q -9 "$FILTEREDFILES"' >> $HOMEFOLDER/temp/$VARIABLE2-$SPORT-$SHORTEN.sh
 			echo '				'"${IONICE}"'nice -n +19 mv "$FILTEREDFILES.bz2" "$DATADIR/$GAMETYPE/$SHORTEN/$FILTEREDFILES.bz2"' >> $HOMEFOLDER/temp/$VARIABLE2-$SPORT-$SHORTEN.sh
@@ -2180,9 +2180,9 @@ function fdl_update {
 			echo '		if [ -f "$DATADIR/$GAMETYPE/$SHORTEN/$FILTEREDFILES.stat" ]; then' >> $HOMEFOLDER/temp/$VARIABLE2-$SPORT-$SHORTEN.sh
 			echo '			if [ "`head -n 1 \"$DATADIR/$GAMETYPE/$SHORTEN/$FILTEREDFILES.stat\"`" != "`'"${IONICE}"'nice -n +19 md5sum \"$FILTEREDFILES\" | awk '"'"'{print $1}'"'"'`" ]; then' >> $HOMEFOLDER/temp/$VARIABLE2-$SPORT-$SHORTEN.sh
 			echo '				'"${IONICE}"'nice -n +19 md5sum "$FILTEREDFILES" | awk '"'"'{print $1}'"'"' > "$DATADIR/$GAMETYPE/$SHORTEN/$FILTEREDFILES.stat"' >> $HOMEFOLDER/temp/$VARIABLE2-$SPORT-$SHORTEN.sh
-			echo '				'"${IONICE}"'nice -n +19 rm "$DATADIR/$GAMETYPE/$SHORTEN/$FILTEREDFILES.stat"' >> $HOMEFOLDER/temp/$VARIABLE2-$SPORT-$SHORTEN.sh
+			echo '				'"${IONICE}"'nice -n +19 rm -f "$DATADIR/$GAMETYPE/$SHORTEN/$FILTEREDFILES.stat"' >> $HOMEFOLDER/temp/$VARIABLE2-$SPORT-$SHORTEN.sh
 			echo '				if [ -f "$DATADIR/$GAMETYPE/$SHORTEN/$FILTEREDFILES.bz2" ]; then' >> $HOMEFOLDER/temp/$VARIABLE2-$SPORT-$SHORTEN.sh
-			echo '					'"${IONICE}"'nice -n +19 rm "$DATADIR/$GAMETYPE/$SHORTEN/$FILTEREDFILES.bz2"' >> $HOMEFOLDER/temp/$VARIABLE2-$SPORT-$SHORTEN.sh
+			echo '					'"${IONICE}"'nice -n +19 rm -f "$DATADIR/$GAMETYPE/$SHORTEN/$FILTEREDFILES.bz2"' >> $HOMEFOLDER/temp/$VARIABLE2-$SPORT-$SHORTEN.sh
 			echo '				fi' >> $HOMEFOLDER/temp/$VARIABLE2-$SPORT-$SHORTEN.sh
 			echo '				'"${IONICE}"'nice -n +19 cp "$FILTEREDFILES" "$DATADIR/$GAMETYPE/$SHORTEN/$FILTEREDFILES"' >> $HOMEFOLDER/temp/$VARIABLE2-$SPORT-$SHORTEN.sh
 			echo '				'"${IONICE}"'nice -n +19 bzip2 -s -q -9 "$DATADIR/$GAMETYPE/$SHORTEN/$FILTEREDFILES"' >> $HOMEFOLDER/temp/$VARIABLE2-$SPORT-$SHORTEN.sh
@@ -2198,7 +2198,7 @@ function fdl_update {
 			echo '		else' >> $HOMEFOLDER/temp/$VARIABLE2-$SPORT-$SHORTEN.sh
 			echo '			'"${IONICE}"'nice -n +19 md5sum "$FILTEREDFILES" | awk '"'"'{print $1}'"'"' > "$DATADIR/$GAMETYPE/$SHORTEN/$FILTEREDFILES.stat"' >> $HOMEFOLDER/temp/$VARIABLE2-$SPORT-$SHORTEN.sh
 			echo '			'"${IONICE}"'nice -n +19 cp "$FILTEREDFILES" "$DATADIR/$GAMETYPE/$SHORTEN/$FILTEREDFILES"' >> $HOMEFOLDER/temp/$VARIABLE2-$SPORT-$SHORTEN.sh
-			echo '			rm "$DATADIR/$GAMETYPE/$SHORTEN/$FILTEREDFILES.bz2"' >> $HOMEFOLDER/temp/$VARIABLE2-$SPORT-$SHORTEN.sh
+			echo '			rm -f "$DATADIR/$GAMETYPE/$SHORTEN/$FILTEREDFILES.bz2"' >> $HOMEFOLDER/temp/$VARIABLE2-$SPORT-$SHORTEN.sh
 			echo '			'"${IONICE}"'nice -n +19 bzip2 -s -q -9 "$DATADIR/$GAMETYPE/$SHORTEN/$FILTEREDFILES"' >> $HOMEFOLDER/temp/$VARIABLE2-$SPORT-$SHORTEN.sh
 			echo '			chmod 660 "$DATADIR/$GAMETYPE/$SHORTEN/$FILTEREDFILES.bz2" "$DATADIR/$GAMETYPE/$SHORTEN/$FILTEREDFILES.stat"' >> $HOMEFOLDER/temp/$VARIABLE2-$SPORT-$SHORTEN.sh
 			echo '			cd $DATADIR/$GAMETYPE/$SHORTEN' >> $HOMEFOLDER/temp/$VARIABLE2-$SPORT-$SHORTEN.sh

--- a/server/easy-wi_install.sh
+++ b/server/easy-wi_install.sh
@@ -195,7 +195,7 @@ if [ "$INSTALL" != 'EW' ]; then
 	if [ "$OPTION" == "Create key" ]; then
 
 		if [ -d /home/$MASTERUSER/.ssh ]; then
-			rm -r /home/$MASTERUSER/.ssh
+			rm -rf /home/$MASTERUSER/.ssh
 		fi
 
 		echo " "
@@ -247,7 +247,7 @@ if [ "$INSTALL" == 'EW' -o  "$INSTALL" == 'WR' ]; then
 							add-apt-repository "deb-src http://packages.dotdeb.org $OSBRANCH all"
 							wget http://www.dotdeb.org/dotdeb.gpg
 							apt-key add dotdeb.gpg
-							rm dotdeb.gpg
+							rm -f dotdeb.gpg
 							apt-get update
 					fi
 			fi
@@ -711,10 +711,10 @@ if [ "$INSTALL" == 'GS' -o "$INSTALL" == 'WR' ]; then
 		echo " "
 		echo " "
 		if [ -f /root/tempfstab ]; then
-			rm /root/tempfstab
+			rm -f /root/tempfstab
 		fi
 		if [ -f /root/tempmountpoints ]; then
-			rm /root/tempmountpoints
+			rm -f /root/tempmountpoints
 		fi
 
 		cat /etc/fstab | while read LINE; do
@@ -749,7 +749,7 @@ if [ "$INSTALL" == 'GS' -o "$INSTALL" == 'WR' ]; then
 		fi
 
 		if [ -f /root/tempfstab ]; then
-			rm /root/tempfstab
+			rm -f /root/tempfstab
 		fi
 
 		if [ -f /root/tempmountpoints ]; then
@@ -759,7 +759,7 @@ if [ "$INSTALL" == 'GS' -o "$INSTALL" == 'WR' ]; then
                 quotaoff -ugv $LINE
 
                 if [ -f $LINE/aquota.user ]; then
-                    rm $LINE/aquota.user
+                    rm -f $LINE/aquota.user
                 fi
 
                 echo "Remounting $LINE"
@@ -769,7 +769,7 @@ if [ "$INSTALL" == 'GS' -o "$INSTALL" == 'WR' ]; then
                 quotaon -uv $LINE
             done
 
-            rm /root/tempmountpoints
+            rm -f /root/tempmountpoints
 		fi
 	fi
 fi
@@ -939,7 +939,7 @@ if [ "$INSTALL" == 'GS' ]; then
 
 	if [ -f steamcmd_linux.tar.gz ]; then
 		tar xfvz steamcmd_linux.tar.gz
-		rm steamcmd_linux.tar.gz
+		rm -f steamcmd_linux.tar.gz
 		chown -R $MASTERUSER:$MASTERUSER /home/$MASTERUSER/masterserver/steamCMD
 		su -c "./steamcmd.sh +login anonymous +quit" $MASTERUSER
 	fi

--- a/server/updates.sh
+++ b/server/updates.sh
@@ -54,7 +54,7 @@ function checkCreateFolder {
 
 function removeFile {
     if [ -f "$1" ]; then
-       rm "$1"
+       rm -f "$1"
     fi
 }
 
@@ -71,7 +71,7 @@ function downloadExtractFile {
     if [ -f "$2" ]; then
 
         tar xfv "$2"
-        rm "$2"
+        rm -f "$2"
 
         moveFilesFolders "$2" "$4" "$1"
 
@@ -187,7 +187,7 @@ function fileUpdate {
             cyanMessage "$3 already up to date. Local version is $LOCAL_VERSION. Most recent version is $CURRENT_VERSION"
         fi
 
-        rm "$FILE_NAME"
+        rm -f "$FILE_NAME"
     fi
 }
 

--- a/web/stuff/methods/class_app.php
+++ b/web/stuff/methods/class_app.php
@@ -108,7 +108,7 @@ class AppServer {
             if ($this->appMasterServerDetails['os'] == 'L') {
                 $this->shellScriptHeader = "#!/bin/bash\n";
                 $this->shellScriptHeader .= "if ionice -c3 true 2>/dev/null; then IONICE='ionice -n 7 '; fi\n";
-                $this->shellScripts['user'] = $this->shellScriptHeader . 'rm /home/' . $this->appMasterServerDetails['ssh2User'] . '/temp/userCud-' . $this->uniqueHex . '.sh' . "\n";
+                $this->shellScripts['user'] = $this->shellScriptHeader . 'rm -f /home/' . $this->appMasterServerDetails['ssh2User'] . '/temp/userCud-' . $this->uniqueHex . '.sh' . "\n";
             }
         }
 
@@ -557,7 +557,7 @@ class AppServer {
 
         $scriptName = $this->removeSlashes('/home/' . $this->appMasterServerDetails['ssh2User'] . '/temp/move-' . $this->appServerDetails['userName'] . '-' . $this->appServerDetails['serverIP'] . '-' . $this->appServerDetails['port'] . '-' . $oldIP . '-' . $oldPort . '.sh');
         $script = $this->shellScriptHeader;
-        $script .= 'rm ' . $scriptName . "\n";
+        $script .= 'rm -f ' . $scriptName . "\n";
         $script .= 'cd ' . $this->removeSlashes($this->appServerDetails['homeDir'] . '/' . $this->appServerDetails['userName'] . '/server') . "\n";
         $script .= 'if [ -d "' . $this->appServerDetails['serverIP'] . '_' . $this->appServerDetails['port']. '" ]; then rm -rf "' . $this->appServerDetails['serverIP'] . '_' . $this->appServerDetails['port'] . '"; fi' . "\n";
         $script .= 'mv ' . $oldIP . '_' . $oldPort . ' ' . $this->appServerDetails['serverIP'] . '_' . $this->appServerDetails['port'] . "\n";
@@ -590,7 +590,7 @@ class AppServer {
 
         if ($standalone and isset($scriptName)) {
             $script = $this->shellScriptHeader;
-            $script .= 'rm ' . $scriptName . "\n";
+            $script .= 'rm -f ' . $scriptName . "\n";
         } else {
             $script = '';
         }
@@ -694,7 +694,7 @@ class AppServer {
         $serverDir = ($this->appServerDetails['protectionModeStarted'] == 'Y') ? 'pserver/' : 'server/';
 
         $script = $this->shellScriptHeader;
-        $script .= 'rm ' . $scriptName . "\n";
+        $script .= 'rm -f ' . $scriptName . "\n";
         $script .= 'cd ' . $this->removeSlashes($this->appServerDetails['homeDir'] . '/' . $this->appServerDetails['userName'] . '/' . $serverDir . $this->appServerDetails['serverIP'] . '_' . $this->appServerDetails['port'] . '/') . "\n";
 
         foreach ($templates as $template) {
@@ -728,7 +728,7 @@ class AppServer {
         if ($standalone === true) {
 
             $script = $this->shellScriptHeader;
-            $script .= 'rm ' . $scriptName . "\n";
+            $script .= 'rm -f ' . $scriptName . "\n";
 
         } else {
             $script = '';
@@ -771,7 +771,7 @@ class AppServer {
             $scriptName = $this->removeSlashes('/home/' . $this->appMasterServerDetails['ssh2User'] . '/temp/stop-' . $this->appServerDetails['userNameExecute'] . '-' . $this->appServerDetails['serverIP'] . '-' . $this->appServerDetails['port'] . '.sh');
 
             $script = $this->shellScriptHeader;
-            $script .= 'rm ' . $scriptName . "\n";
+            $script .= 'rm -f ' . $scriptName . "\n";
 
         } else {
             $script = '';
@@ -841,7 +841,7 @@ class AppServer {
         $scriptName = $this->removeSlashes('/home/' . $this->appMasterServerDetails['ssh2User'] . '/temp/hardstop-' . $userName . '.sh');
 
         $script = $this->shellScriptHeader;
-        $script .= 'rm ' . $scriptName . "\n";
+        $script .= 'rm -f ' . $scriptName . "\n";
 
         $script .= 'crontab -r' . "\n";
         $script .= 'screen -wipe > /dev/null 2>&1' . "\n";
@@ -1353,7 +1353,7 @@ class AppServer {
         $serverTemplateDir = $this->removeSlashes($serverDir . '/' . $this->appServerDetails['serverIP'] . '_' . $this->appServerDetails['port'] . '/');
 
         $script = $this->shellScriptHeader;
-        $script .= 'rm ' . $scriptName . "\n";
+        $script .= 'rm -f ' . $scriptName . "\n";
 
         $script .= $this->linuxStopApp(false, $scriptName);
 
@@ -1385,7 +1385,7 @@ class AppServer {
 
             $script .= 'for BADFILE in ${FILESFOUND[@]}; do' . "\n";
             $script .= 'chmod 666 $BADFILE > /dev/null 2>&1' . "\n";
-            $script .= 'rm $BADFILE > /dev/null 2>&1' . "\n";
+            $script .= 'rm -f $BADFILE > /dev/null 2>&1' . "\n";
             $script .= 'if [ -f $BADFILE ]; then exit 0; fi' . "\n";
             $script .= 'done' . "\n";
         }
@@ -1413,7 +1413,7 @@ class AppServer {
             $script .= 'if [ "$BINARY_DIR" != "" ]; then cd "$BINARY_DIR"; fi' . "\n";
 		}
 
-        $script .= 'if [ -f screenlog.0 ]; then rm screenlog.0; fi' . "\n";
+        $script .= 'if [ -f screenlog.0 ]; then rm -f screenlog.0; fi' . "\n";
         $script .= $this->generateStartCommand() . "\n";
 
         if ($this->getGameType() == 'hl2' and $this->appServerDetails['tvAllowed'] == 'Y' and in_array($this->appServerDetails['app']['upload'], array(4, 5)) and $this->appServerDetails['app']['uploadDir']) {
@@ -1463,7 +1463,7 @@ class AppServer {
 
         if ($standalone == true) {
             $script = $this->shellScriptHeader;
-            $script .= 'rm ' . $scriptName . "\n";
+            $script .= 'rm -f ' . $scriptName . "\n";
         } else {
             $script = '';
         }
@@ -1537,7 +1537,7 @@ class AppServer {
                 $screenScriptName = $this->removeSlashes('/home/' . $this->appMasterServerDetails['ssh2User'] . '/temp/demo-start-' . $this->appServerDetails['userNameExecute'] . '-' . $this->appServerDetails['serverIP'] . '-' . $this->appServerDetails['port'] . '.sh');
 
                 $script = $this->shellScriptHeader;
-                $script .= 'rm ' . $screenScriptName . "\n";
+                $script .= 'rm -f ' . $screenScriptName . "\n";
 
                 // Kill any screen that is running with the same name
                 $script .= 'ps fx | grep \'SCREEN\' | grep \'demo_' . $this->appServerDetails['serverIP'] . '_' . $this->appServerDetails['port'] . '\' | grep -v grep | awk \'{print $1}\' | while read PID; do' . "\n";
@@ -1640,7 +1640,7 @@ class AppServer {
         $scriptName = $this->removeSlashes('/home/' . $this->appMasterServerDetails['ssh2User'] . '/temp/addons-add-' . $this->appServerDetails['userNameExecute'] . '-' . $this->appServerDetails['serverIP'] . '-' . $this->appServerDetails['port'] . '.sh');
 
         $script = $this->shellScriptHeader;
-        $script .= 'rm ' . $scriptName . "\n";
+        $script .= 'rm -f ' . $scriptName . "\n";
 
         if ($id === false) {
 
@@ -1735,13 +1735,13 @@ class AppServer {
         $script .= 'mv $GAMEDIR/$FILES.old $GAMEDIR/$FILES' . "\n";
         $script .= 'elif [ "`basename $FILES`" == "plugins.ini" ]; then' . "\n";
 
-        $script .= 'if [ -f /home/' . $this->appMasterServerDetails['ssh2User'] . '/temp/$USER.pluginlist.temp ]; then rm /home/' . $this->appMasterServerDetails['ssh2User'] . '/temp/$USER.pluginlist.temp; fi' . "\n";
+        $script .= 'if [ -f /home/' . $this->appMasterServerDetails['ssh2User'] . '/temp/$USER.pluginlist.temp ]; then rm -f /home/' . $this->appMasterServerDetails['ssh2User'] . '/temp/$USER.pluginlist.temp; fi' . "\n";
 
         $script .= 'cat $GAMEDIR/$FILES | while read LINE; do' . "\n";
         $script .= 'if [[ `grep "$LINE" $FILES` == "" ]]; then  echo "$LINE" >> /home/' . $this->appMasterServerDetails['ssh2User'] . '/temp/$USER.pluginlist.temp; fi' . "\n";
         $script .= 'done' . "\n";
         $script .= 'cp /home/' . $this->appMasterServerDetails['ssh2User'] . '/temp/$USER.pluginlist.temp $GAMEDIR/$FILES' . "\n";
-        $script .= 'rm /home/' . $this->appMasterServerDetails['ssh2User'] . '/temp/$USER.pluginlist.temp' . "\n";
+        $script .= 'rm -f /home/' . $this->appMasterServerDetails['ssh2User'] . '/temp/$USER.pluginlist.temp' . "\n";
         $script .= 'else' . "\n";
         $script .= 'rm -rf "$GAMEDIR/$FILES" > /dev/null 2>&1' . "\n";
         $script .= 'if [ "$FILES" == "liblist.gam" ]; then mv $GAMEDIR/$FILES.old $GAMEDIR/$FILES > /dev/null 2>&1; fi' . "\n";
@@ -1765,7 +1765,7 @@ class AppServer {
         $scriptName = $this->removeSlashes('/home/' . $this->appMasterServerDetails['ssh2User'] . '/temp/addons-del-' . $this->appServerDetails['userNameExecute'] . '-' . $this->appServerDetails['serverIP'] . '-' . $this->appServerDetails['port'] . '.sh');
 
         $script = $this->shellScriptHeader;
-        $script .= 'rm ' . $scriptName . "\n";
+        $script .= 'rm -f ' . $scriptName . "\n";
         $script .= 'USER=`id -un`' . "\n";
 
         foreach ($ids as $id) {
@@ -1823,7 +1823,7 @@ class AppServer {
         $scriptName = $this->removeSlashes('/home/' . $this->appMasterServerDetails['ssh2User'] . '/temp/migrate-' . $this->appServerDetails['userName'] . '-' . $this->appServerDetails['serverIP'] . '-' . $this->appServerDetails['port'] . '.sh');
 
         $script = $this->shellScriptHeader;
-        $script .= 'rm ' . $scriptName . "\n";
+        $script .= 'rm -f ' . $scriptName . "\n";
         $script .= 'if [ -d "' . $serverDir . '" ]; then ${IONICE}rm -rf "' . $serverDir . '"; fi' . "\n";
 
         $script .= $this->linuxAddApp(array($targetTemplate), false);
@@ -1869,7 +1869,7 @@ class AppServer {
             $scriptName = $this->removeSlashes('/home/' . $this->appMasterServerDetails['ssh2User'] . '/temp/fdl-sync-' . $this->appServerDetails['userName'] . '-' . $this->appServerDetails['serverIP'] . '-' . $this->appServerDetails['port'] . '.sh');
 
             $script = $this->shellScriptHeader;
-            $script .= 'rm ' . $scriptName . "\n";
+            $script .= 'rm -f ' . $scriptName . "\n";
             $script .= 'USERNAME=`id -un`' . "\n";
 
             $script .= 'if [ -f "' . $fdlFileList . '" ]; then' . "\n";
@@ -1996,7 +1996,7 @@ class AppServer {
         $scriptName = $this->removeSlashes('/home/' . $this->appMasterServerDetails['ssh2User'] . '/temp/backup-create-' . $this->appServerDetails['userName'] . '-' . $this->appServerDetails['serverIP'] . '-' . $this->appServerDetails['port'] . '.sh');
 
         $script = $this->shellScriptHeader;
-        $script .= 'rm ' . $scriptName . "\n";
+        $script .= 'rm -f ' . $scriptName . "\n";
 
         $script .= 'if [ ! -d "' . $backupDir . '" ]; then mkdir -p "' . $backupDir . '"; fi' . "\n";
         $script .= 'find "' . $backupDir . '" -maxdepth 1 -type f -name "*.tar.bz2" -delete' . "\n";
@@ -2033,7 +2033,7 @@ class AppServer {
         $scriptName = $this->removeSlashes('/home/' . $this->appMasterServerDetails['ssh2User'] . '/temp/backup-deploy-' . $this->appServerDetails['userName'] . '-' . $this->appServerDetails['serverIP'] . '-' . $this->appServerDetails['port'] . '.sh');
 
         $script = $this->shellScriptHeader;
-        $script .= 'rm ' . $scriptName . "\n";
+        $script .= 'rm -f ' . $scriptName . "\n";
 
         if (strlen($ftpDownloadString) > 0) {
             $script .= 'if [ ! -d "' . $backupDir . '" ]; then mkdir -p "' . $backupDir . '"; fi' . "\n";
@@ -2041,7 +2041,7 @@ class AppServer {
             $script .= 'mv "' . $this->removeSlashes($backupDir . '/' . $this->appServerDetails['serverIP'] . '_' . $this->appServerDetails['port'] . '-' . $template . '.tar.bz2"') . '" "' . $this->removeSlashes($backupDir . '/' . $this->appServerDetails['serverIP'] . '_' . $this->appServerDetails['port'] . '-' . $template . '_old.tar.bz2"') . "\n";
             $script .= 'wget -q --timeout=10 --no-check-certificate ' . $ftpDownloadString . '/' . $this->appServerDetails['serverIP'] . '_' . $this->appServerDetails['port'] . '-' . $template . '.tar.bz2' . "\n";
             $script .= 'if [ -f "' . $this->removeSlashes($backupDir . '/' . $this->appServerDetails['serverIP'] . '_' . $this->appServerDetails['port'] . '-' . $template . '.tar.bz2"') . '" ]; then' . "\n";
-            $script .= 'rm "' . $this->removeSlashes($backupDir . '/' . $this->appServerDetails['serverIP'] . '_' . $this->appServerDetails['port'] . '-' . $template . '_old.tar.bz2"') . "\n";
+            $script .= 'rm -f "' . $this->removeSlashes($backupDir . '/' . $this->appServerDetails['serverIP'] . '_' . $this->appServerDetails['port'] . '-' . $template . '_old.tar.bz2"') . "\n";
             $script .= 'else' . "\n";
             $script .= 'mv "' . $this->removeSlashes($backupDir . '/' . $this->appServerDetails['serverIP'] . '_' . $this->appServerDetails['port'] . '-' . $template . '_old.tar.bz2"') . '" "' . $this->removeSlashes($backupDir . '/' . $this->appServerDetails['serverIP'] . '_' . $this->appServerDetails['port'] . '-' . $template . '.tar.bz2"') . "\n";
             $script .= 'fi' . "\n";

--- a/web/stuff/methods/class_masterserver.php
+++ b/web/stuff/methods/class_masterserver.php
@@ -249,7 +249,7 @@ class masterServer {
         $this->uniqueHex = dechex(mt_rand());
 
         $this->shellScript = "#!/bin/bash\n";
-        $this->shellScript .= 'rm /home/' . $this->sshuser . '/temp/master-' . $this->uniqueHex . '.sh' . "\n";
+        $this->shellScript .= 'rm -f /home/' . $this->sshuser . '/temp/master-' . $this->uniqueHex . '.sh' . "\n";
         $this->shellScript .= "if ionice -c3 true 2>/dev/null; then IONICE='ionice -n 7 '; else IONICE=''; fi\n";
         $this->shellScript .= 'UPDATESTATUS=""' . "\n";
         $this->shellScript .= 'BOMRM="sed \"\'s/^\xef\xbb\xbf//g\'\""' . "\n";
@@ -283,7 +283,7 @@ class masterServer {
         $this->shellScript .= 'wget -q --timeout=10 http://media.steampowered.com/client/steamcmd_linux.tar.gz' . "\n";
         $this->shellScript .= 'if [ -f steamcmd_linux.tar.gz ]; then' . "\n";
         $this->shellScript .= 'tar xfz steamcmd_linux.tar.gz' . "\n";
-        $this->shellScript .= 'rm steamcmd_linux.tar.gz' . "\n";
+        $this->shellScript .= 'rm -f steamcmd_linux.tar.gz' . "\n";
         $this->shellScript .= 'chmod +x steamcmd.sh' . "\n";
         $this->shellScript .= './steamcmd.sh +login anonymous +quit' . "\n";
         $this->shellScript .= 'fi' . "\n";
@@ -343,7 +343,7 @@ class masterServer {
 
         $fastDownloadList = '/home/' . $this->sshuser . '/conf/fdl-' . $row['shorten'] . '.list';
 
-        $this->shellScript .= 'if [ -f ' . $fastDownloadList . ' ]; then rm ' . $fastDownloadList . '; fi' . "\n";
+        $this->shellScript .= 'if [ -f ' . $fastDownloadList . ' ]; then rm -f ' . $fastDownloadList . '; fi' . "\n";
         $this->shellScript .= 'touch ' . $fastDownloadList . "\n";
         $this->shellScript .= 'cd "' . $this->masterserverDir . '$UPDATE"' . "\n";
         $this->shellScript .= 'SEARCH=0' . "\n";
@@ -609,10 +609,10 @@ class masterServer {
         if (count($this->removeLogs) > 0) {
 
             $shellScript = '#!/bin/bash'. "\n";
-            $shellScript .= 'rm /home/' . $this->sshuser . '/temp/remove-update-logs-' . $this->uniqueHex . '.sh'. "\n";
+            $shellScript .= 'rm -f /home/' . $this->sshuser . '/temp/remove-update-logs-' . $this->uniqueHex . '.sh'. "\n";
 
             foreach ($this->removeLogs as $log) {
-                $shellScript .= 'if [ -f "' . $log . '" ]; then rm "' . $log . '"; fi' . "\n";
+                $shellScript .= 'if [ -f "' . $log . '" ]; then rm -f "' . $log . '"; fi' . "\n";
             }
 
             return $shellScript;


### PR DESCRIPTION
In some OSes (like CentOS) `rm` is a blocking command requireing you to say `Yes` if you want to proceed deleting a file:

    rm: remove regular empty file ‘test’?

You can disable this behaviour by using the parameter `-f`