### PR TITLE
ftpPassword im Startbefehl

### DIFF
--- a/web/stuff/methods/class_app.php
+++ b/web/stuff/methods/class_app.php
@@ -262,7 +262,7 @@ class AppServer {
             $lendDetails = array('rcon' => '', 'password' => '', 'slots' => $this->appServerDetails['slots']);
         }
 
-        $placeholder = array('%binary%', '%tickrate%', '%tic%', '%ip%', '%port%', '%tvport%', '%port2%', '%port3%', '%port4%', '%port5%', '%slots%', '%map%', '%mapgroup%', '%fps%', '%minram%', '%maxram%', '%maxcores%', '%folder%', '%user%', '%absolutepath%');
+        $placeholder = array('%binary%', '%tickrate%', '%tic%', '%ip%', '%port%', '%tvport%', '%port2%', '%port3%', '%port4%', '%port5%', '%slots%', '%map%', '%mapgroup%', '%fps%', '%minram%', '%maxram%', '%maxcores%', '%folder%', '%user%', '%absolutepath%', '%ftpPassword%');
 
         $replacePlaceholderWith = array(
             $this->appServerDetails['template']['gameBinary'],
@@ -284,7 +284,8 @@ class AppServer {
             $this->appServerDetails['maxCores'],
             $this->appServerDetails['app']['templateChoosen'],
             $this->appServerDetails['userName'],
-            $this->appServerDetails['absolutePath']
+            $this->appServerDetails['absolutePath'],
+            $this->appServerDetails['ftpPassword']
         );
 
         return array('placeholder' => $placeholder, 'replacePlaceholderWith' => $replacePlaceholderWith);


### PR DESCRIPTION
Mit Dieser Änderung wird das generierte "ftpPassword" im Startbefehl verfügbar gemacht.

Da es bei einigen Spielen notwendig ist, ein rcon Passwort im Startbefehl zu vergeben, kann man somit das FTP Passwort auch als rcon Passwort verwenden und man muss nicht immer eins händisch eintragen.

Vielleicht geht dies ja noch eleganter und man erstellt für das rcon Passwort eine extra Variable.