### PR TITLE
fixing suhosin check

### DIFF
--- a/stuff/admin/voice_tsdns.php
+++ b/stuff/admin/voice_tsdns.php
@@ -234,7 +234,7 @@ if ($ui->w('action',4, 'post') and !token(true)) {
                     $maxRequests = @ini_get('suhosin.request.max_vars');
                     $i = 0;
                     $max = ($maxRequests and $maxPost and $maxPost<$maxRequests) ? $maxPost : $maxRequests;
-                    $max = (isset($max)) ? ($max-10)/7 : count($dnsarray);
+                    $max = (empty($max)) ? ($max-10)/7 : count($dnsarray);
 
                     $dnsarray = tsdns('li', $ssh2ip, $ssh2port, $ssh2user, $publickey, $keyname, $ssh2password, 'N', $serverdir, $bit, array(''), array(''), array(''), $reseller_id);
 
@@ -305,7 +305,7 @@ if ($ui->w('action',4, 'post') and !token(true)) {
                 $maxRequests = @ini_get('suhosin.request.max_vars');
                 $i = 0;
                 $max = ($maxRequests and $maxPost and $maxPost<$maxRequests) ? $maxPost : $maxRequests;
-                $max = (isset($max)) ? ($max-10)/7 : count($dnsarray);
+                $max = (empty($max)) ? ($max-10)/7 : count($dnsarray);
 
                 $query = $sql->prepare("SELECT `id`,`cname`,`vname`,`name` FROM `userdata` WHERE `resellerid`=? AND `accounttype`='u' ORDER BY `id` DESC");
                 $query->execute(array($reseller_id));


### PR DESCRIPTION
ini_get returns the value of the configuration option as a string on success, or an empty string for null values. Returns FALSE if the configuration option doesn't exist (http://php.net/manual/de/function.ini-get.php).
Therefore isset($max) can never be false. We should use empty($max) to check for setups not using suhosin.