### PR TITLE
fixing suhosin check 2

### DIFF
--- a/stuff/admin/voice_tsdns.php
+++ b/stuff/admin/voice_tsdns.php
@@ -234,7 +234,7 @@ if ($ui->w('action',4, 'post') and !token(true)) {
                     $maxRequests = @ini_get('suhosin.request.max_vars');
                     $i = 0;
                     $max = ($maxRequests and $maxPost and $maxPost<$maxRequests) ? $maxPost : $maxRequests;
-                    $max = (empty($max)) ? ($max-10)/7 : count($dnsarray);
+                    $max = (empty($max)) ? count($dnsarray) : ($max-10)/7;
 
                     $dnsarray = tsdns('li', $ssh2ip, $ssh2port, $ssh2user, $publickey, $keyname, $ssh2password, 'N', $serverdir, $bit, array(''), array(''), array(''), $reseller_id);
 
@@ -305,7 +305,7 @@ if ($ui->w('action',4, 'post') and !token(true)) {
                 $maxRequests = @ini_get('suhosin.request.max_vars');
                 $i = 0;
                 $max = ($maxRequests and $maxPost and $maxPost<$maxRequests) ? $maxPost : $maxRequests;
-                $max = (empty($max)) ? ($max-10)/7 : count($dnsarray);
+                $max = (empty($max)) ? count($dnsarray) : ($max-10)/7;
 
                 $query = $sql->prepare("SELECT `id`,`cname`,`vname`,`name` FROM `userdata` WHERE `resellerid`=? AND `accounttype`='u' ORDER BY `id` DESC");
                 $query->execute(array($reseller_id));


### PR DESCRIPTION
When using empty($max) the follwowing two expression need to be switched.
If Suhosin is not installed @ini_get('suhosin.post.max_vars') and @ini_get('suhosin.request.max_vars') will return false. empty($max) will return true and count($dnsarray) should be set as $max.
...Took me only one year to notice I missed that change here last time.