### PR TITLE
Don't scream out passwords on overview

### DIFF
--- a/template/New/user/userpanel_gserver_list.tpl
+++ b/template/New/user/userpanel_gserver_list.tpl
@@ -158,7 +158,7 @@
                      <?php if(($pa['ftpaccess'] or $pa['miniroot']) and $table_row['ftpAllowed']) { ?>
                      <li class="list-group-item"><b><?php echo $sprache->ftp_link;?>:</b>
                      <a href="<?php echo $table_row['ftpdata'];?>">
-                     <?php echo $table_row['ftpdata'];?>
+                     <?php echo str_replace($table_row['cftppass'], str_repeat("*", strlen($table_row['cftppass'])), $table_row['ftpdata']);?>
                      </a>
                      </li>
                      <?php } ?>
@@ -169,7 +169,8 @@
                      <?php echo $table_row['cname'];?>
                      </li>
                      <li class="list-group-item"><b><?php echo $sprache->ftp_password;?>:</b>
-                     <?php echo $table_row['cftppass'];?>
+                     <div id="cftppass-<?php echo $gsa; ?>" style="display:none"><?php echo $table_row['cftppass'];?></div>
+                     <button title="" class="btn btn-outline-warning inline" type="button" onclick="if(document.getElementById('cftppass-<?php echo $gsa; ?>') .style.display=='none') {document.getElementById('cftppass-<?php echo $gsa; ?>') .style.display='inline'}else{document.getElementById('cftppass-<?php echo $gsa; ?>') .style.display='none'}"><i class="fa fa-eye"></i></button>
                      </li>
                      <li class="list-group-item"></li>
                      </ul>


### PR DESCRIPTION
Don't print ftp password by default. Prevents accidental leaks / screengrabs of sensitive infos.

**NOTE:** This is a dirty patch thrown together in like 10 mins using inline Javascript for the "Show/Hide". You may use a more sane attempt using inbuild jquery or whatever. I was too lazy for adding JS to proper files.

![patch-1](https://user-images.githubusercontent.com/3930214/89728382-42f5a600-da2d-11ea-9d21-1b5a33e59086.png)